### PR TITLE
ci(workflows): disable npm cache in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "18"
-          cache: "npm"
+          # cache: "npm"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
The npm cache was disabled to prevent potential conflicts with pnpm installation