### PR TITLE
ci: remove docker registry from workflow and use username directly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Login to Docker Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ secrets.DOCKER_REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
@@ -64,8 +63,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ secrets.DOCKER_REGISTRY }}/vnc-booking-fe:latest
-            ${{ secrets.DOCKER_REGISTRY }}/vnc-booking-fe:${{ github.sha }}
+            ${{ secrets.DOCKER_USERNAME }}/vnc-booking-fe:latest
+            ${{ secrets.DOCKER_USERNAME }}/vnc-booking-fe:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
Simplify docker image tagging by removing registry prefix and using username directly